### PR TITLE
Add Get All Customers endpoint

### DIFF
--- a/source/RewardsService/rewardsservice/handlers/rewards_handler.py
+++ b/source/RewardsService/rewardsservice/handlers/rewards_handler.py
@@ -73,6 +73,15 @@ class GetCustomer(tornado.web.RequestHandler):
         self.write(json.dumps(customer))
 
 
+class GetAllCustomers(tornado.web.RequestHandler):
+
+    def get(self):
+        client = MongoClient("mongodb", 27017)
+        dbc = client["Customers"]
+        customer = list(dbc.customers.find({}, {"_id": 0}))
+        self.write(json.dumps(customer))
+
+
 def get_reward_info(points):
 
     current_points = (points // 100) * 100

--- a/source/RewardsService/rewardsservice/url_patterns.py
+++ b/source/RewardsService/rewardsservice/url_patterns.py
@@ -1,7 +1,8 @@
-from handlers.rewards_handler import RewardsHandler, ManageCustomer, GetCustomer
+from handlers.rewards_handler import RewardsHandler, ManageCustomer, GetCustomer, GetAllCustomers
 
 url_patterns = [
     (r'/rewards', RewardsHandler),
     (r'/manage_customer', ManageCustomer),
     (r'/get_customer/([^/]+)', GetCustomer),
+    (r'/get_all_customers', GetAllCustomers),
 ]


### PR DESCRIPTION
Add api endpoint to return all customer data
Url to access a customers data is http://localhost:7050/get_all_customers
Returns data in a list as a json payload