### PR TITLE
Added Add Orders form

### DIFF
--- a/source/RewardsService/rewardsservice/handlers/rewards_handler.py
+++ b/source/RewardsService/rewardsservice/handlers/rewards_handler.py
@@ -28,16 +28,16 @@ class ManageCustomer(tornado.web.RequestHandler):
 
         # Check if email_address or order_total were not in the post data
         if not email_address or not order_total:
-            return(self.write("Error: Missing data"))
+            return(self.write(json.dumps({'order_error': "Missing data"})))
 
         # Check if email address is valid
         if not check_email(email_address):
-            return(self.write("Error: Invalid Email Address"))
+            return(self.write(json.dumps({'order_error': "Invalid Email Address"})))
 
         # Check if order_total is valid
         point_total = check_order_total(order_total)
         if not point_total:
-            return(self.write("Error: Invalid Order Total"))
+            return(self.write(json.dumps({'order_error': "Invalid Order Total"})))
 
         # Search DB for customer, add or update
         db = client["Customers"]
@@ -58,6 +58,8 @@ class ManageCustomer(tornado.web.RequestHandler):
             reward_info = get_reward_info(point_total)
             reward_info.update({'email_address': email_address})
             db.customers.insert(reward_info)
+
+        self.write(json.dumps({'order_success': "Order added successfully!"}))
 
 
 class GetCustomer(tornado.web.RequestHandler):

--- a/source/RewardsUI/rewards/clients/rewards_service_client.py
+++ b/source/RewardsUI/rewards/clients/rewards_service_client.py
@@ -5,7 +5,12 @@ class RewardsServiceClient:
 
     def __init__(self):
         self.rewards_url = "http://rewardsservice:7050/rewards"
+        self.order_url = "http://rewardsservice:7050/manage_customer"
 
     def get_rewards(self):
         response = requests.get(self.rewards_url)
+        return response.json()
+
+    def add_order(self, email_address, order_total):
+        response = requests.post(self.order_url, data={'email_address': email_address, 'order_total': order_total})
         return response.json()

--- a/source/RewardsUI/rewards/index.html
+++ b/source/RewardsUI/rewards/index.html
@@ -23,9 +23,12 @@
     </div>
     <div>
         <h2>Add orders</h2>
-        <form>
-            <label>Enter email address: </label><input type="text"/><br>
-            <label>Enter order total: </label><input type="text"/><input type="button" value="Submit Order"/>
+        {% if order_error %}<h3>{{ order_error }}</h3>{% endif %}
+        {% if order_success %}<h3>{{ order_success }}</h3>{% endif %}
+        <form method="post" action="{{ request.path }}">
+            <label>Enter email address: </label><input type="text" name="email_address"/><br>
+            <label>Enter order total: </label><input type="text" name="order_total"/><input type="submit" value="Submit Order"/>
+            {% csrf_token %}
         </form>
         <hr>
     </div>

--- a/source/RewardsUI/rewards/views.py
+++ b/source/RewardsUI/rewards/views.py
@@ -24,3 +24,20 @@ class RewardsView(TemplateView):
             self.template_name,
             context
         )
+
+    def post(self, request, *args, **kwargs):
+        context = self.get_context_data(**kwargs)
+        email_address = request.POST.get("email_address", None)
+        order_total = request.POST.get("order_total", None)
+
+        rewards_data = self.rewards_service_client.get_rewards()
+        context['rewards_data'] = rewards_data
+
+        order_data = self.rewards_service_client.add_order(email_address, order_total)
+        context.update(order_data)
+
+        return TemplateResponse(
+            request,
+            self.template_name,
+            context
+        )


### PR DESCRIPTION
Add new form action to http://localhost:8000/rewards/ page, Add orders.
User enters an email and order total, then submits to the RewardsService API.
The result of this upload then gets displayed above the form.

Also the RewardsService Api, ManageCustomer endpoint was updated to provide more standardized data returned. Instead of just a text message being displayed, the api now returns either order_error, or order_success in a json object.

