### PR TITLE
Add User Rewards Section

### DIFF
--- a/source/RewardsUI/rewards/clients/rewards_service_client.py
+++ b/source/RewardsUI/rewards/clients/rewards_service_client.py
@@ -6,6 +6,8 @@ class RewardsServiceClient:
     def __init__(self):
         self.rewards_url = "http://rewardsservice:7050/rewards"
         self.order_url = "http://rewardsservice:7050/manage_customer"
+        self.customer_url = "http://rewardsservice:7050/get_customer/"
+        self.all_customers_url = "http://rewardsservice:7050/get_all_customers"
 
     def get_rewards(self):
         response = requests.get(self.rewards_url)
@@ -13,4 +15,13 @@ class RewardsServiceClient:
 
     def add_order(self, email_address, order_total):
         response = requests.post(self.order_url, data={'email_address': email_address, 'order_total': order_total})
+        return response.json()
+
+    def get_customer(self, email_search):
+        url = self.customer_url + email_search
+        response = requests.get(url)
+        return response.json()
+
+    def get_customers(self):
+        response = requests.get(self.all_customers_url)
         return response.json()

--- a/source/RewardsUI/rewards/index.html
+++ b/source/RewardsUI/rewards/index.html
@@ -34,8 +34,10 @@
     </div>
     <div>
         <h2>User Rewards</h2>
-        <form>
-            <label>Email address: </label><input type="text"/><input type="button" value="Search"/>
+        {% if search_error %}<h3>{{ search_error }}</h3>{% endif %}
+        <form method="post" action="{{ request.path }}">
+            <label>Email address: </label><input type="text" name="email_search"/><input type="submit" value="Search"/>
+            {% csrf_token %}
         </form>
         <table border="1">
             <thead>
@@ -50,15 +52,17 @@
             </tr>
             </thead>
             <tbody>
+                {% for customer in customers_data %}
                 <tr>
-                    <td>customer01@gmail.com</td>
-                    <td>100</td>
-                    <td>A</td>
-                    <td>5% off purchase</td>
-                    <td>B</td>
-                    <td>10% off purchase</td>
-                    <td>50%</td>
+                    <td>{{ customer.email_address }}</td>
+                    <td>{{ customer.reward_points }}</td>
+                    <td>{{ customer.reward_tier }}</td>
+                    <td>{{ customer.reward_tier_name }}</td>
+                    <td>{{ customer.next_reward_tier }}</td>
+                    <td>{{ customer.next_reward_tier_name }}</td>
+                    <td>{{ customer.next_reward_tier_progress }}</td>
                 </tr>
+                {% endfor %}
             </tbody>
         </table>
     </div>

--- a/source/RewardsUI/rewards/views.py
+++ b/source/RewardsUI/rewards/views.py
@@ -19,6 +19,9 @@ class RewardsView(TemplateView):
         rewards_data = self.rewards_service_client.get_rewards()
         context['rewards_data'] = rewards_data
 
+        customers_data = self.rewards_service_client.get_customers()
+        context['customers_data'] = customers_data
+
         return TemplateResponse(
             request,
             self.template_name,
@@ -29,12 +32,22 @@ class RewardsView(TemplateView):
         context = self.get_context_data(**kwargs)
         email_address = request.POST.get("email_address", None)
         order_total = request.POST.get("order_total", None)
+        email_search = request.POST.get("email_search", None)
 
         rewards_data = self.rewards_service_client.get_rewards()
         context['rewards_data'] = rewards_data
 
-        order_data = self.rewards_service_client.add_order(email_address, order_total)
-        context.update(order_data)
+        if email_search:
+            customers_data = self.rewards_service_client.get_customer(email_search)
+            context['customers_data'] = [customers_data]
+            if not customers_data:
+                context['search_error'] = "Search returned 0 results"
+
+        else:
+            order_data = self.rewards_service_client.add_order(email_address, order_total)
+            context.update(order_data)
+            customers_data = self.rewards_service_client.get_customers()
+            context['customers_data'] = customers_data
 
         return TemplateResponse(
             request,


### PR DESCRIPTION
Add new form action and table to the User Rewards section on the http://localhost:8000/rewards/ dashboard.
The table now shows All user data, using the http://localhoast:7050/get_all_customers api endpoint.
Using the form a user can enter an email address to search for using the http://localhoast:7050/get_customer/<<email_address>> api endpoint.
If the search does not return a record, the form shows the message "Search returned 0 results".